### PR TITLE
Add Apple Music and Spotify links where missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ A collective list of music to listen to while programming. [Please contribute!](
 
 | Name                            | Artist               | Type     | Link                                                                |
 | ------------------------------- | -------------------- | -------- | ------------------------------------------------------------------- |
-| Circular Symmetry               | ATB                  | Song     | [Spotify](https://open.spotify.com/track/7CR0lIrkxYmHThUbqluw9J)    |
+| Circular Symmetry               | ATB                  | Song     | [Apple Music](https://music.apple.com/album/305853678), [Spotify](https://open.spotify.com/track/7CR0lIrkxYmHThUbqluw9J)
 | Chillstep Music for Programming | Chill Music Lab      | Playlist | [YouTube](https://www.youtube.com/watch?v=M5QY2_8704o)              |
-| Kontor Sunset Chill             | Various              | Playlist | [Spotify](https://open.spotify.com/playlist/4qfIDDItu9xWo8LsrqOAca) |
-| Radio Retaliation               | Thievery Corporation | Album    | [Spotify](https://open.spotify.com/album/7JK0l9nae3EcV6C1lz4LlG)    |
-| The Cosmic Game                 | Thievery Corporation | Album    | [Spotify](https://open.spotify.com/album/3x31ejKrrjJWXGd6ftaSNu)    |
+| Kontor Deep House 2022          | Various              | Playlist | [Apple Music](https://music.apple.com/playlist/pl.0bc7c2a86ae846849aa6853797d41328), [Spotify](https://open.spotify.com/playlist/4qfIDDItu9xWo8LsrqOAca)
+| Radio Retaliation               | Thievery Corporation | Album    | [Apple Music](https://music.apple.com/album/299040135), [Spotify](https://open.spotify.com/album/7JK0l9nae3EcV6C1lz4LlG)
+| The Cosmic Game                 | Thievery Corporation | Album    | [Apple Music](https://music.apple.com/album/277521724), [Spotify](https://open.spotify.com/album/3x31ejKrrjJWXGd6ftaSNu)
 
 ### Drum & Bass
 
@@ -36,23 +36,23 @@ A collective list of music to listen to while programming. [Please contribute!](
 
 | Name                               | Artist                           | Type       | Link                                                                                 |
 | ---------------------------------- | -------------------------------- | ---------- | ------------------------------------------------------------------------------------ |
-| Discovery                          | Daft Punk                        | Album      | [Spotify](https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc)                     |
-| Emergence                          | Max Cooper                       | Album      | [Spotify](https://open.spotify.com/album/26vmJ6CjPxYWYYa2B4d9my)                     |
-| Full Circle                        | HÆLOS                            | Album      | [Spotify](https://open.spotify.com/album/3kE0d3eZX1EjoWMeHQTvXQ)                     |
-| Half Age EP                        | Weval                            | Album      | [Spotify](https://open.spotify.com/album/1hDdP4atpaoKA5OE8ETG1u)                     |
-| Halt and Catch Fire (TV OST)       | Paul Haslinger                   | Album      | [Spotify](https://open.spotify.com/album/6SREPA19KJrxIfMhijErlF)                     |
-| Halt and Catch Fire Vol 2 (TV OST) | Paul Haslinger                   | Album      | [Spotify](https://open.spotify.com/album/4fgDSpwYFqCBxt47QlDqC8)                     |
-| Mantra                             | Jean du Voyage                   | Album      | [Spotify](https://open.spotify.com/album/7K5tfkdeToVwZaEnEv2atb)                     |
+| Discovery                          | Daft Punk                        | Album      | [Apple Music](https://music.apple.com/album/697194953), [Spotify](https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc)
+| Emergence                          | Max Cooper                       | Album      | [Apple Music](https://music.apple.com/album/1149398778), [Spotify](https://open.spotify.com/album/26vmJ6CjPxYWYYa2B4d9my)
+| Full Circle                        | HÆLOS                            | Album      | [Apple Music](https://music.apple.com/album/1589172754), [Spotify](https://open.spotify.com/album/3kE0d3eZX1EjoWMeHQTvXQ)
+| Half Age EP                        | Weval                            | Album      | [Apple Music](https://music.apple.com/album/1522057259), [Spotify](https://open.spotify.com/album/1hDdP4atpaoKA5OE8ETG1u)
+| Halt and Catch Fire (TV OST)       | Paul Haslinger                   | Album      | [Apple Music](https://music.apple.com/album/1141609067), [Spotify](https://open.spotify.com/album/6SREPA19KJrxIfMhijErlF)
+| Halt and Catch Fire Vol 2 (TV OST) | Paul Haslinger                   | Album      | [Apple Music](https://music.apple.com/album/1446955010), [Spotify](https://open.spotify.com/album/4fgDSpwYFqCBxt47QlDqC8)
+| Mantra                             | Jean du Voyage                   | Album      | [Apple Music](https://music.apple.com/album/1153711013), [Spotify](https://open.spotify.com/album/7K5tfkdeToVwZaEnEv2atb)
 | Minimal Techno                     | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/alekzanther/playlist/0B3WoheGNqol1B69LM9Y8n) |
-| Mirror's Edge (Game OST)           | Solar Fields                     | Album      | [Spotify](https://open.spotify.com/album/3x8kUWCtDfOEnOtyaRdkdp)                     |
-| Music Has the Right to Children    | Boards Of Canada                 | Album      | [Spotify](https://open.spotify.com/album/1vWnB0hYmluskQuzxwo25a)                     |
-| Random Access Memories             | Daft Punk                        | Album      | [Spotify](https://open.spotify.com/album/4m2880jivSbbyEGAKfITCa)                     |
+| Mirror's Edge (Game OST)           | Solar Fields                     | Album      | [Apple Music](https://music.apple.com/album/1530511640), [Spotify](https://open.spotify.com/album/3x8kUWCtDfOEnOtyaRdkdp)
+| Music Has the Right to Children    | Boards Of Canada                 | Album      | [Apple Music](https://music.apple.com/album/281116024), [Spotify](https://open.spotify.com/album/1vWnB0hYmluskQuzxwo25a)
+| Random Access Memories             | Daft Punk                        | Album      | [Apple Music](https://music.apple.com/album/617154241), [Spotify](https://open.spotify.com/album/4m2880jivSbbyEGAKfITCa)
 | Ratatat mix                        | Ratatat                          | Playlist   | [Spotify](https://open.spotify.com/user/ciroivan227/playlist/1eLgUY4BFj7f96z10womVL) |
-| Solar Eclipses                     | Hollywood Principle, Dr. Awkward | Album      | [Spotify](https://open.spotify.com/album/2PGeNYKwJPCfImBFA1CcC8)                     |
+| Solar Eclipses                     | Hollywood Principle, Dr. Awkward | Album      | [Apple Music](https://music.apple.com/album/1312553828), [Spotify](https://open.spotify.com/album/2PGeNYKwJPCfImBFA1CcC8)
 | Techno Bunker                      | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX6J5NfMJS675)     |
-| The Aviating                       | Alec Toniq & Gabriel Vitel       | Album      | [Apple Music](https://music.apple.com/de/album/the-aviating/1051088498)              |
-| The Social Network                 | Trent Reznor, Atticus Ross       | Soundtrack | [Spotify](https://open.spotify.com/album/1ijkFiMeHopKkHyvQCWxUa)                     |
-| TRON: Legacy                       | Daft Punk                        | Soundtrack | [Spotify](https://open.spotify.com/album/40EZGFRJY2R43IPiOnFelG)                     |
+| The Aviating                       | Alec Troniq & Gabriel Vitel      | Album      | [Apple Music](https://music.apple.com/de/album/the-aviating/1051088498), [Spotify](https://open.spotify.com/album/4gSJzDHKILotDwmE1YSZA3)
+| The Social Network                 | Trent Reznor, Atticus Ross       | Soundtrack | [Apple Music](https://music.apple.com/album/395740920), [Spotify](https://open.spotify.com/album/1ijkFiMeHopKkHyvQCWxUa)
+| TRON: Legacy                       | Daft Punk                        | Soundtrack | [Apple Music](https://music.apple.com/album/1440617583), [Spotify](https://open.spotify.com/album/40EZGFRJY2R43IPiOnFelG)
 | Wired In                           | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/tomzorzhu/playlist/6FBP8geEcJX2lYnsVxfvYl)   |
 | RetroWave / Outrun                 | Various                          | Playlist   | [Spotify](https://open.spotify.com/playlist/37i9dQZF1DXdLEN7aqioXM)                  |
 
@@ -60,16 +60,16 @@ A collective list of music to listen to while programming. [Please contribute!](
 
 | Name                     | Artist              | Type       | Link                                                                             |
 | ------------------------ | ------------------- | ---------- | -------------------------------------------------------------------------------- |
-| A Moment Of Stillness    | God Is An Astronaut | Album      | [Spotify](https://open.spotify.com/album/1eVrXeDRsZQFM4DtSbUzKr)                 |
-| Atomic                   | Mogwai              | Album      | [Spotify](https://open.spotify.com/album/56tg3CAAd9JZhzQZsYoC2c)                 |
+| A Moment Of Stillness    | God Is An Astronaut | Album      | [Apple Music](https://music.apple.com/album/491771172), [Spotify](https://open.spotify.com/album/1eVrXeDRsZQFM4DtSbUzKr)
+| Atomic                   | Mogwai              | Album      | [Apple Music](https://music.apple.com/album/1073144598), [Spotify](https://open.spotify.com/album/56tg3CAAd9JZhzQZsYoC2c)
 | Audiomachine             | Audiomachine        | Playlist   | [Spotify](https://open.spotify.com/artist/5F4ObszoeVebqtc0B3XqJa)                |
-| Helios / Erebus          | God Is An Astronaut | Album      | [Spotify](https://open.spotify.com/album/6NEwj8hlw0b7U3jd6vHRg3)                 |
-| Interstellar             | Hans Zimmer         | Soundtrack | [Spotify](https://open.spotify.com/album/5OVGwMCexoHavOar6v4al5)                 |
-| Les Revenants Soundtrack | Mogwai              | Soundtrack | [Spotify](https://open.spotify.com/album/7znNGZ8iNfLJ41IxEWYJHp)                 |
-| Philharmonics            | Agnes Obel          | Album      | [Apple Music](https://music.apple.com/de/album/philharmonics/872505332)          |
+| Helios / Erebus          | God Is An Astronaut | Album      | [Apple Music](https://music.apple.com/album/1009018992), [Spotify](https://open.spotify.com/album/6NEwj8hlw0b7U3jd6vHRg3)
+| Interstellar             | Hans Zimmer         | Soundtrack | [Apple Music](https://music.apple.com/album/1533983552), [Spotify](https://open.spotify.com/album/5OVGwMCexoHavOar6v4al5)
+| Les Revenants Soundtrack | Mogwai              | Soundtrack | [Apple Music](https://music.apple.com/album/598102671), [Spotify](https://open.spotify.com/album/7znNGZ8iNfLJ41IxEWYJHp)
+| Philharmonics            | Agnes Obel          | Album      | [Apple Music](https://music.apple.com/de/album/philharmonics/872505332), [Spotify](https://open.spotify.com/album/1hOKjrormSHpyOw0BREwEx)
 | Productive Morning       | Various             | Playlist   | [Spotify](https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX6T5dWVv97mp) |
-| Time                     | Hans Zimmer         | Soundtrack | [Spotify](https://open.spotify.com/track/6ZFbXIJkuI1dVNWvzJzown)                 |
-| Vapor                    | Yosi Horikawa       | Album      | [Spotify](https://open.spotify.com/album/1IpHSURAZpaIlAkLX8vqGt)                 |
+| Time                     | Hans Zimmer         | Song       | [Apple Music](https://music.apple.com/album/380349905?i=380350246), [Spotify](https://open.spotify.com/track/6ZFbXIJkuI1dVNWvzJzown)
+| Vapor                    | Yosi Horikawa       | Album      | [Apple Music](https://music.apple.com/album/643071275), [Spotify](https://open.spotify.com/album/1IpHSURAZpaIlAkLX8vqGt)
 
 ### Hip Hop
 
@@ -107,35 +107,35 @@ A collective list of music to listen to while programming. [Please contribute!](
 | Name                                     | Artist         | Type     | Link                                                                              |
 | ---------------------------------------- | -------------- | -------- | --------------------------------------------------------------------------------- |
 | Ambience while coding                    | Various        | Playlist | [Spotify](https://open.spotify.com/user/resalire/playlist/3Z8uzEtTyX2qmpXX4ZXV7p) |
-| Oracle                                   | Sorastro       | Album    | [Spotify](https://open.spotify.com/album/1sCRvOl9mclwED42jGULVn)                  |
-| Project Reality Original Soundtrack v0.9 | Scott Tobin    | Album    | [Spotify](https://open.spotify.com/album/2qW0y29VGdFOAfGff92gbh)                  |
-| Project Reality Original Soundtrack v1.0 | Scott Tobin    | Album    | [Spotify](https://open.spotify.com/album/0Krzwyda9zwkfmdI8UcIx6)                  |
-| Starborn                                 | Sorastro       | Album    | [Spotify](https://open.spotify.com/album/6RgumQtb6jbqvDfd6XRtUC)                  |
-| Unearthed                                | E.S. Posthumus | Album    | [Spotify](https://open.spotify.com/album/5dO8FBozMXBNXRwuGbYt12)                  |
+| Oracle                                   | Sorastro       | Album    | [Apple Music](https://music.apple.com/album/1412353597), [Spotify](https://open.spotify.com/album/1sCRvOl9mclwED42jGULVn)
+| Project Reality Original Soundtrack v0.9 | Scott Tobin    | Album    | [Apple Music](https://music.apple.com/album/367558171), [Spotify](https://open.spotify.com/album/2qW0y29VGdFOAfGff92gbh)
+| Project Reality Original Soundtrack v1.0 | Scott Tobin    | Album    | [Apple Music](https://music.apple.com/album/775826832), [Spotify](https://open.spotify.com/album/0Krzwyda9zwkfmdI8UcIx6)
+| Starborn                                 | Sorastro       | Album    | [Apple Music](https://music.apple.com/album/1294791957), [Spotify](https://open.spotify.com/album/6RgumQtb6jbqvDfd6XRtUC)
+| Unearthed                                | E.S. Posthumus | Album    | [Apple Music](https://music.apple.com/album/39436966), [Spotify](https://open.spotify.com/album/5dO8FBozMXBNXRwuGbYt12)
 
 ### Post-Rock
 
 | Name                            | Artist                | Type  | Link                                                             |
 | ------------------------------- | --------------------- | ----- | ---------------------------------------------------------------- |
-| All of a Sudden I Miss Everyone | Explosions In The Sky | Album | [Spotify](https://open.spotify.com/album/1hXFXoYkWp7Jbzc2nwhvub) |
-| Hand Cannot Erase               | Steven Wilson         | Album | [Spotify](https://open.spotify.com/album/30ibtgslgzmMRbQnWl9LTy) |
-| Hvarf - Heim                    | Sigur Rós             | Album | [Spotify](https://open.spotify.com/album/28WGXFGJNfTHxUoIsnIYVn) |
-| In Absentia                     | Porcupine Tree        | Album | [Spotify](https://open.spotify.com/album/2dAYkfqPYzOTDNxDDVP2vi) |
-| The Incident                    | Porcupine Tree        | Album | [Spotify](https://open.spotify.com/album/4yUOsJbwypC2JrpXZ3eO7p) |
-| The Raven That Refused to Sing  | Steven Wilson         | Album | [Spotify](https://open.spotify.com/album/62sXcCLmRTvVrmOOsuHGiJ) |
-| Those Who Tell the Truth        | Explosions In The Sky | Album | [Spotify](https://open.spotify.com/album/0HxOFNk6NIHydHAer8y01M) |
-| To The Bone                     | Steven Wilson         | Album | [Spotify](https://open.spotify.com/album/37lL4QxxvHJ3SxFH2KtkDD) |
+| All of a Sudden I Miss Everyone | Explosions In The Sky | Album | [Apple Music](https://music.apple.com/album/923356909), [Spotify](https://open.spotify.com/album/1hXFXoYkWp7Jbzc2nwhvub)
+| Hand Cannot Erase               | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/947842870), [Spotify](https://open.spotify.com/album/30ibtgslgzmMRbQnWl9LTy)
+| Hvarf - Heim                    | Sigur Rós             | Album | [Apple Music](https://music.apple.com/album/710454556), [Spotify](https://open.spotify.com/album/28WGXFGJNfTHxUoIsnIYVn)
+| In Absentia                     | Porcupine Tree        | Album | [Apple Music](https://music.apple.com/album/1577152462), [Spotify](https://open.spotify.com/album/2dAYkfqPYzOTDNxDDVP2vi)
+| The Incident                    | Porcupine Tree        | Album | [Apple Music](https://music.apple.com/album/1532131566), [Spotify](https://open.spotify.com/album/4yUOsJbwypC2JrpXZ3eO7p)
+| The Raven That Refused to Sing  | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/684102613), [Spotify](https://open.spotify.com/album/62sXcCLmRTvVrmOOsuHGiJ)
+| Those Who Tell the Truth        | Explosions In The Sky | Album | [Apple Music](https://music.apple.com/album/318950013), [Spotify](https://open.spotify.com/album/0HxOFNk6NIHydHAer8y01M)
+| To The Bone                     | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/1440885200), [Spotify](https://open.spotify.com/album/37lL4QxxvHJ3SxFH2KtkDD)
 
 ### Space/Ambient
 
 | Name                 | Artist          | Type       | Link                                                                           |
 | -------------------- | --------------- | ---------- | ------------------------------------------------------------------------------ |
-| Immunity             | Jon Hopkins     | Album      | [Spotify](https://open.spotify.com/album/1rxWlYQcH945S3jpIMYR35)               |
-| Light Years          | Stellardrone    | Album      | [Spotify](https://open.spotify.com/album/6uQHo7feNU73mKn8X69pwk)               |
-| Movements            | Solar Fields    | Album      | [Spotify](https://open.spotify.com/album/26sqA3KtarBkOXvR33FNQs)               |
-| No Man's Sky OST     | 65daysofstatic  | Soundtrack | [Spotify](https://open.spotify.com/album/0CkuFPWCLJjCAEKy0dce40)               |
-| Spiral Revelation    | Steve Roach     | Album      | [Spotify](https://open.spotify.com/album/0t7qmuEWN8vtKOJEqzm5T6)               |
+| Immunity             | Jon Hopkins     | Album      | [Apple Music](https://music.apple.com/album/766062577), [Spotify](https://open.spotify.com/album/1rxWlYQcH945S3jpIMYR35)
+| Light Years          | Stellardrone    | Album      | [Apple Music](https://music.apple.com/album/669237623), [Spotify](https://open.spotify.com/album/6uQHo7feNU73mKn8X69pwk)
+| Movements            | Solar Fields    | Album      | [Apple Music](https://music.apple.com/album/1572605925), [Spotify](https://open.spotify.com/album/26sqA3KtarBkOXvR33FNQs)
+| No Man's Sky OST     | 65daysofstatic  | Soundtrack | [Apple Music](https://music.apple.com/album/1469726921), [Spotify](https://open.spotify.com/album/0CkuFPWCLJjCAEKy0dce40)
+| Spiral Revelation    | Steve Roach     | Album      | [Apple Music](https://music.apple.com/album/1184455247), [Spotify](https://open.spotify.com/album/0t7qmuEWN8vtKOJEqzm5T6)
 | Synthwave from Space | Various         | Playlist   | [Spotify](https://open.spotify.com/user/aofd3/playlist/4sgUux9hmykyWYmVoe4W6p) |
-| The Apollo Missions  | NASA            | Playlist   | [Spotify](https://open.spotify.com/album/3uC3GbmL0BaTIFnrpByd0D)               |
-| Tycho Anthology      | Tycho           | Playlist   | [Spotify](https://open.spotify.com/playlist/7m3EiJHdRAVPweCJLxDP3d)            |
-| X3 OST               | Alexei Zakharov | Soundtrack | [Spotify](https://open.spotify.com/artist/0V2HC7qeeg8gpoO8cs7ZZX)              |
+| The Apollo Missions  | NASA            | Album      | [Spotify](https://open.spotify.com/album/3uC3GbmL0BaTIFnrpByd0D)               |
+| Tycho Anthology      | Tycho           | Playlist   | [Apple Music](https://music.apple.com/de/playlist/pl.u-55D6XYqTYb1VZY), [Spotify](https://open.spotify.com/playlist/7m3EiJHdRAVPweCJLxDP3d)
+| X3 OST               | Alexei Zakharov | Soundtrack | [Apple Music](https://music.apple.com/album/495207937), [Spotify](https://open.spotify.com/artist/0V2HC7qeeg8gpoO8cs7ZZX)

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ A collective list of music to listen to while programming. [Please contribute!](
 
 ### Chillout
 
-| Name                            | Artist               | Type     | Link                                                                |
-| ------------------------------- | -------------------- | -------- | ------------------------------------------------------------------- |
-| Circular Symmetry               | ATB                  | Song     | [Apple Music](https://music.apple.com/album/305853678), [Spotify](https://open.spotify.com/track/7CR0lIrkxYmHThUbqluw9J)
-| Chillstep Music for Programming | Chill Music Lab      | Playlist | [YouTube](https://www.youtube.com/watch?v=M5QY2_8704o)              |
-| Kontor Deep House 2022          | Various              | Playlist | [Apple Music](https://music.apple.com/playlist/pl.0bc7c2a86ae846849aa6853797d41328), [Spotify](https://open.spotify.com/playlist/4qfIDDItu9xWo8LsrqOAca)
-| Radio Retaliation               | Thievery Corporation | Album    | [Apple Music](https://music.apple.com/album/299040135), [Spotify](https://open.spotify.com/album/7JK0l9nae3EcV6C1lz4LlG)
-| The Cosmic Game                 | Thievery Corporation | Album    | [Apple Music](https://music.apple.com/album/277521724), [Spotify](https://open.spotify.com/album/3x31ejKrrjJWXGd6ftaSNu)
+| Name                            | Artist               | Type     | Link                                                                                                                                                     |
+| ------------------------------- | -------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Circular Symmetry               | ATB                  | Song     | [Apple Music](https://music.apple.com/album/305853678), [Spotify](https://open.spotify.com/track/7CR0lIrkxYmHThUbqluw9J)                                 |
+| Chillstep Music for Programming | Chill Music Lab      | Playlist | [YouTube](https://www.youtube.com/watch?v=M5QY2_8704o)                                                                                                   |
+| Kontor Deep House 2022          | Various              | Playlist | [Apple Music](https://music.apple.com/playlist/pl.0bc7c2a86ae846849aa6853797d41328), [Spotify](https://open.spotify.com/playlist/4qfIDDItu9xWo8LsrqOAca) |
+| Radio Retaliation               | Thievery Corporation | Album    | [Apple Music](https://music.apple.com/album/299040135), [Spotify](https://open.spotify.com/album/7JK0l9nae3EcV6C1lz4LlG)                                 |
+| The Cosmic Game                 | Thievery Corporation | Album    | [Apple Music](https://music.apple.com/album/277521724), [Spotify](https://open.spotify.com/album/3x31ejKrrjJWXGd6ftaSNu)                                 |
 
 ### Drum & Bass
 
@@ -34,42 +34,42 @@ A collective list of music to listen to while programming. [Please contribute!](
 
 ### Electronic
 
-| Name                               | Artist                           | Type       | Link                                                                                 |
-| ---------------------------------- | -------------------------------- | ---------- | ------------------------------------------------------------------------------------ |
-| Discovery                          | Daft Punk                        | Album      | [Apple Music](https://music.apple.com/album/697194953), [Spotify](https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc)
-| Emergence                          | Max Cooper                       | Album      | [Apple Music](https://music.apple.com/album/1149398778), [Spotify](https://open.spotify.com/album/26vmJ6CjPxYWYYa2B4d9my)
-| Full Circle                        | HÆLOS                            | Album      | [Apple Music](https://music.apple.com/album/1589172754), [Spotify](https://open.spotify.com/album/3kE0d3eZX1EjoWMeHQTvXQ)
-| Half Age EP                        | Weval                            | Album      | [Apple Music](https://music.apple.com/album/1522057259), [Spotify](https://open.spotify.com/album/1hDdP4atpaoKA5OE8ETG1u)
-| Halt and Catch Fire (TV OST)       | Paul Haslinger                   | Album      | [Apple Music](https://music.apple.com/album/1141609067), [Spotify](https://open.spotify.com/album/6SREPA19KJrxIfMhijErlF)
-| Halt and Catch Fire Vol 2 (TV OST) | Paul Haslinger                   | Album      | [Apple Music](https://music.apple.com/album/1446955010), [Spotify](https://open.spotify.com/album/4fgDSpwYFqCBxt47QlDqC8)
-| Mantra                             | Jean du Voyage                   | Album      | [Apple Music](https://music.apple.com/album/1153711013), [Spotify](https://open.spotify.com/album/7K5tfkdeToVwZaEnEv2atb)
-| Minimal Techno                     | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/alekzanther/playlist/0B3WoheGNqol1B69LM9Y8n) |
-| Mirror's Edge (Game OST)           | Solar Fields                     | Album      | [Apple Music](https://music.apple.com/album/1530511640), [Spotify](https://open.spotify.com/album/3x8kUWCtDfOEnOtyaRdkdp)
-| Music Has the Right to Children    | Boards Of Canada                 | Album      | [Apple Music](https://music.apple.com/album/281116024), [Spotify](https://open.spotify.com/album/1vWnB0hYmluskQuzxwo25a)
-| Random Access Memories             | Daft Punk                        | Album      | [Apple Music](https://music.apple.com/album/617154241), [Spotify](https://open.spotify.com/album/4m2880jivSbbyEGAKfITCa)
-| Ratatat mix                        | Ratatat                          | Playlist   | [Spotify](https://open.spotify.com/user/ciroivan227/playlist/1eLgUY4BFj7f96z10womVL) |
-| Solar Eclipses                     | Hollywood Principle, Dr. Awkward | Album      | [Apple Music](https://music.apple.com/album/1312553828), [Spotify](https://open.spotify.com/album/2PGeNYKwJPCfImBFA1CcC8)
-| Techno Bunker                      | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX6J5NfMJS675)     |
-| The Aviating                       | Alec Troniq & Gabriel Vitel      | Album      | [Apple Music](https://music.apple.com/de/album/the-aviating/1051088498), [Spotify](https://open.spotify.com/album/4gSJzDHKILotDwmE1YSZA3)
-| The Social Network                 | Trent Reznor, Atticus Ross       | Soundtrack | [Apple Music](https://music.apple.com/album/395740920), [Spotify](https://open.spotify.com/album/1ijkFiMeHopKkHyvQCWxUa)
-| TRON: Legacy                       | Daft Punk                        | Soundtrack | [Apple Music](https://music.apple.com/album/1440617583), [Spotify](https://open.spotify.com/album/40EZGFRJY2R43IPiOnFelG)
-| Wired In                           | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/tomzorzhu/playlist/6FBP8geEcJX2lYnsVxfvYl)   |
-| RetroWave / Outrun                 | Various                          | Playlist   | [Spotify](https://open.spotify.com/playlist/37i9dQZF1DXdLEN7aqioXM)                  |
+| Name                               | Artist                           | Type       | Link                                                                                                                                      |
+| ---------------------------------- | -------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Discovery                          | Daft Punk                        | Album      | [Apple Music](https://music.apple.com/album/697194953), [Spotify](https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc)                  |
+| Emergence                          | Max Cooper                       | Album      | [Apple Music](https://music.apple.com/album/1149398778), [Spotify](https://open.spotify.com/album/26vmJ6CjPxYWYYa2B4d9my)                 |
+| Full Circle                        | HÆLOS                            | Album      | [Apple Music](https://music.apple.com/album/1589172754), [Spotify](https://open.spotify.com/album/3kE0d3eZX1EjoWMeHQTvXQ)                 |
+| Half Age EP                        | Weval                            | Album      | [Apple Music](https://music.apple.com/album/1522057259), [Spotify](https://open.spotify.com/album/1hDdP4atpaoKA5OE8ETG1u)                 |
+| Halt and Catch Fire (TV OST)       | Paul Haslinger                   | Album      | [Apple Music](https://music.apple.com/album/1141609067), [Spotify](https://open.spotify.com/album/6SREPA19KJrxIfMhijErlF)                 |
+| Halt and Catch Fire Vol 2 (TV OST) | Paul Haslinger                   | Album      | [Apple Music](https://music.apple.com/album/1446955010), [Spotify](https://open.spotify.com/album/4fgDSpwYFqCBxt47QlDqC8)                 |
+| Mantra                             | Jean du Voyage                   | Album      | [Apple Music](https://music.apple.com/album/1153711013), [Spotify](https://open.spotify.com/album/7K5tfkdeToVwZaEnEv2atb)                 |
+| Minimal Techno                     | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/alekzanther/playlist/0B3WoheGNqol1B69LM9Y8n)                                                      |
+| Mirror's Edge (Game OST)           | Solar Fields                     | Album      | [Apple Music](https://music.apple.com/album/1530511640), [Spotify](https://open.spotify.com/album/3x8kUWCtDfOEnOtyaRdkdp)                 |
+| Music Has the Right to Children    | Boards Of Canada                 | Album      | [Apple Music](https://music.apple.com/album/281116024), [Spotify](https://open.spotify.com/album/1vWnB0hYmluskQuzxwo25a)                  |
+| Random Access Memories             | Daft Punk                        | Album      | [Apple Music](https://music.apple.com/album/617154241), [Spotify](https://open.spotify.com/album/4m2880jivSbbyEGAKfITCa)                  |
+| Ratatat mix                        | Ratatat                          | Playlist   | [Spotify](https://open.spotify.com/user/ciroivan227/playlist/1eLgUY4BFj7f96z10womVL)                                                      |
+| Solar Eclipses                     | Hollywood Principle, Dr. Awkward | Album      | [Apple Music](https://music.apple.com/album/1312553828), [Spotify](https://open.spotify.com/album/2PGeNYKwJPCfImBFA1CcC8)                 |
+| Techno Bunker                      | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX6J5NfMJS675)                                                          |
+| The Aviating                       | Alec Troniq & Gabriel Vitel      | Album      | [Apple Music](https://music.apple.com/de/album/the-aviating/1051088498), [Spotify](https://open.spotify.com/album/4gSJzDHKILotDwmE1YSZA3) |
+| The Social Network                 | Trent Reznor, Atticus Ross       | Soundtrack | [Apple Music](https://music.apple.com/album/395740920), [Spotify](https://open.spotify.com/album/1ijkFiMeHopKkHyvQCWxUa)                  |
+| TRON: Legacy                       | Daft Punk                        | Soundtrack | [Apple Music](https://music.apple.com/album/1440617583), [Spotify](https://open.spotify.com/album/40EZGFRJY2R43IPiOnFelG)                 |
+| Wired In                           | Various                          | Playlist   | [Spotify](https://open.spotify.com/user/tomzorzhu/playlist/6FBP8geEcJX2lYnsVxfvYl)                                                        |
+| RetroWave / Outrun                 | Various                          | Playlist   | [Spotify](https://open.spotify.com/playlist/37i9dQZF1DXdLEN7aqioXM)                                                                       |
 
 ### Focus
 
-| Name                     | Artist              | Type       | Link                                                                             |
-| ------------------------ | ------------------- | ---------- | -------------------------------------------------------------------------------- |
-| A Moment Of Stillness    | God Is An Astronaut | Album      | [Apple Music](https://music.apple.com/album/491771172), [Spotify](https://open.spotify.com/album/1eVrXeDRsZQFM4DtSbUzKr)
-| Atomic                   | Mogwai              | Album      | [Apple Music](https://music.apple.com/album/1073144598), [Spotify](https://open.spotify.com/album/56tg3CAAd9JZhzQZsYoC2c)
-| Audiomachine             | Audiomachine        | Playlist   | [Spotify](https://open.spotify.com/artist/5F4ObszoeVebqtc0B3XqJa)                |
-| Helios / Erebus          | God Is An Astronaut | Album      | [Apple Music](https://music.apple.com/album/1009018992), [Spotify](https://open.spotify.com/album/6NEwj8hlw0b7U3jd6vHRg3)
-| Interstellar             | Hans Zimmer         | Soundtrack | [Apple Music](https://music.apple.com/album/1533983552), [Spotify](https://open.spotify.com/album/5OVGwMCexoHavOar6v4al5)
-| Les Revenants Soundtrack | Mogwai              | Soundtrack | [Apple Music](https://music.apple.com/album/598102671), [Spotify](https://open.spotify.com/album/7znNGZ8iNfLJ41IxEWYJHp)
-| Philharmonics            | Agnes Obel          | Album      | [Apple Music](https://music.apple.com/de/album/philharmonics/872505332), [Spotify](https://open.spotify.com/album/1hOKjrormSHpyOw0BREwEx)
-| Productive Morning       | Various             | Playlist   | [Spotify](https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX6T5dWVv97mp) |
-| Time                     | Hans Zimmer         | Song       | [Apple Music](https://music.apple.com/album/380349905?i=380350246), [Spotify](https://open.spotify.com/track/6ZFbXIJkuI1dVNWvzJzown)
-| Vapor                    | Yosi Horikawa       | Album      | [Apple Music](https://music.apple.com/album/643071275), [Spotify](https://open.spotify.com/album/1IpHSURAZpaIlAkLX8vqGt)
+| Name                     | Artist              | Type       | Link                                                                                                                                      |
+| ------------------------ | ------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| A Moment Of Stillness    | God Is An Astronaut | Album      | [Apple Music](https://music.apple.com/album/491771172), [Spotify](https://open.spotify.com/album/1eVrXeDRsZQFM4DtSbUzKr)                  |
+| Atomic                   | Mogwai              | Album      | [Apple Music](https://music.apple.com/album/1073144598), [Spotify](https://open.spotify.com/album/56tg3CAAd9JZhzQZsYoC2c)                 |
+| Audiomachine             | Audiomachine        | Playlist   | [Spotify](https://open.spotify.com/artist/5F4ObszoeVebqtc0B3XqJa)                                                                         |
+| Helios / Erebus          | God Is An Astronaut | Album      | [Apple Music](https://music.apple.com/album/1009018992), [Spotify](https://open.spotify.com/album/6NEwj8hlw0b7U3jd6vHRg3)                 |
+| Interstellar             | Hans Zimmer         | Soundtrack | [Apple Music](https://music.apple.com/album/1533983552), [Spotify](https://open.spotify.com/album/5OVGwMCexoHavOar6v4al5)                 |
+| Les Revenants Soundtrack | Mogwai              | Soundtrack | [Apple Music](https://music.apple.com/album/598102671), [Spotify](https://open.spotify.com/album/7znNGZ8iNfLJ41IxEWYJHp)                  |
+| Philharmonics            | Agnes Obel          | Album      | [Apple Music](https://music.apple.com/de/album/philharmonics/872505332), [Spotify](https://open.spotify.com/album/1hOKjrormSHpyOw0BREwEx) |
+| Productive Morning       | Various             | Playlist   | [Spotify](https://open.spotify.com/user/spotify/playlist/37i9dQZF1DX6T5dWVv97mp)                                                          |
+| Time                     | Hans Zimmer         | Song       | [Apple Music](https://music.apple.com/album/380349905?i=380350246), [Spotify](https://open.spotify.com/track/6ZFbXIJkuI1dVNWvzJzown)      |
+| Vapor                    | Yosi Horikawa       | Album      | [Apple Music](https://music.apple.com/album/643071275), [Spotify](https://open.spotify.com/album/1IpHSURAZpaIlAkLX8vqGt)                  |
 
 ### Hip Hop
 
@@ -104,38 +104,38 @@ A collective list of music to listen to while programming. [Please contribute!](
 
 ### Orchestral
 
-| Name                                     | Artist         | Type     | Link                                                                              |
-| ---------------------------------------- | -------------- | -------- | --------------------------------------------------------------------------------- |
-| Ambience while coding                    | Various        | Playlist | [Spotify](https://open.spotify.com/user/resalire/playlist/3Z8uzEtTyX2qmpXX4ZXV7p) |
-| Oracle                                   | Sorastro       | Album    | [Apple Music](https://music.apple.com/album/1412353597), [Spotify](https://open.spotify.com/album/1sCRvOl9mclwED42jGULVn)
-| Project Reality Original Soundtrack v0.9 | Scott Tobin    | Album    | [Apple Music](https://music.apple.com/album/367558171), [Spotify](https://open.spotify.com/album/2qW0y29VGdFOAfGff92gbh)
-| Project Reality Original Soundtrack v1.0 | Scott Tobin    | Album    | [Apple Music](https://music.apple.com/album/775826832), [Spotify](https://open.spotify.com/album/0Krzwyda9zwkfmdI8UcIx6)
-| Starborn                                 | Sorastro       | Album    | [Apple Music](https://music.apple.com/album/1294791957), [Spotify](https://open.spotify.com/album/6RgumQtb6jbqvDfd6XRtUC)
-| Unearthed                                | E.S. Posthumus | Album    | [Apple Music](https://music.apple.com/album/39436966), [Spotify](https://open.spotify.com/album/5dO8FBozMXBNXRwuGbYt12)
+| Name                                     | Artist         | Type     | Link                                                                                                                      |
+| ---------------------------------------- | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Ambience while coding                    | Various        | Playlist | [Spotify](https://open.spotify.com/user/resalire/playlist/3Z8uzEtTyX2qmpXX4ZXV7p)                                         |
+| Oracle                                   | Sorastro       | Album    | [Apple Music](https://music.apple.com/album/1412353597), [Spotify](https://open.spotify.com/album/1sCRvOl9mclwED42jGULVn) |
+| Project Reality Original Soundtrack v0.9 | Scott Tobin    | Album    | [Apple Music](https://music.apple.com/album/367558171), [Spotify](https://open.spotify.com/album/2qW0y29VGdFOAfGff92gbh)  |
+| Project Reality Original Soundtrack v1.0 | Scott Tobin    | Album    | [Apple Music](https://music.apple.com/album/775826832), [Spotify](https://open.spotify.com/album/0Krzwyda9zwkfmdI8UcIx6)  |
+| Starborn                                 | Sorastro       | Album    | [Apple Music](https://music.apple.com/album/1294791957), [Spotify](https://open.spotify.com/album/6RgumQtb6jbqvDfd6XRtUC) |
+| Unearthed                                | E.S. Posthumus | Album    | [Apple Music](https://music.apple.com/album/39436966), [Spotify](https://open.spotify.com/album/5dO8FBozMXBNXRwuGbYt12)   |
 
 ### Post-Rock
 
-| Name                            | Artist                | Type  | Link                                                             |
-| ------------------------------- | --------------------- | ----- | ---------------------------------------------------------------- |
-| All of a Sudden I Miss Everyone | Explosions In The Sky | Album | [Apple Music](https://music.apple.com/album/923356909), [Spotify](https://open.spotify.com/album/1hXFXoYkWp7Jbzc2nwhvub)
-| Hand Cannot Erase               | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/947842870), [Spotify](https://open.spotify.com/album/30ibtgslgzmMRbQnWl9LTy)
-| Hvarf - Heim                    | Sigur Rós             | Album | [Apple Music](https://music.apple.com/album/710454556), [Spotify](https://open.spotify.com/album/28WGXFGJNfTHxUoIsnIYVn)
-| In Absentia                     | Porcupine Tree        | Album | [Apple Music](https://music.apple.com/album/1577152462), [Spotify](https://open.spotify.com/album/2dAYkfqPYzOTDNxDDVP2vi)
-| The Incident                    | Porcupine Tree        | Album | [Apple Music](https://music.apple.com/album/1532131566), [Spotify](https://open.spotify.com/album/4yUOsJbwypC2JrpXZ3eO7p)
-| The Raven That Refused to Sing  | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/684102613), [Spotify](https://open.spotify.com/album/62sXcCLmRTvVrmOOsuHGiJ)
-| Those Who Tell the Truth        | Explosions In The Sky | Album | [Apple Music](https://music.apple.com/album/318950013), [Spotify](https://open.spotify.com/album/0HxOFNk6NIHydHAer8y01M)
-| To The Bone                     | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/1440885200), [Spotify](https://open.spotify.com/album/37lL4QxxvHJ3SxFH2KtkDD)
+| Name                            | Artist                | Type  | Link                                                                                                                      |
+| ------------------------------- | --------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------- |
+| All of a Sudden I Miss Everyone | Explosions In The Sky | Album | [Apple Music](https://music.apple.com/album/923356909), [Spotify](https://open.spotify.com/album/1hXFXoYkWp7Jbzc2nwhvub)  |
+| Hand Cannot Erase               | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/947842870), [Spotify](https://open.spotify.com/album/30ibtgslgzmMRbQnWl9LTy)  |
+| Hvarf - Heim                    | Sigur Rós             | Album | [Apple Music](https://music.apple.com/album/710454556), [Spotify](https://open.spotify.com/album/28WGXFGJNfTHxUoIsnIYVn)  |
+| In Absentia                     | Porcupine Tree        | Album | [Apple Music](https://music.apple.com/album/1577152462), [Spotify](https://open.spotify.com/album/2dAYkfqPYzOTDNxDDVP2vi) |
+| The Incident                    | Porcupine Tree        | Album | [Apple Music](https://music.apple.com/album/1532131566), [Spotify](https://open.spotify.com/album/4yUOsJbwypC2JrpXZ3eO7p) |
+| The Raven That Refused to Sing  | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/684102613), [Spotify](https://open.spotify.com/album/62sXcCLmRTvVrmOOsuHGiJ)  |
+| Those Who Tell the Truth        | Explosions In The Sky | Album | [Apple Music](https://music.apple.com/album/318950013), [Spotify](https://open.spotify.com/album/0HxOFNk6NIHydHAer8y01M)  |
+| To The Bone                     | Steven Wilson         | Album | [Apple Music](https://music.apple.com/album/1440885200), [Spotify](https://open.spotify.com/album/37lL4QxxvHJ3SxFH2KtkDD) |
 
 ### Space/Ambient
 
-| Name                 | Artist          | Type       | Link                                                                           |
-| -------------------- | --------------- | ---------- | ------------------------------------------------------------------------------ |
-| Immunity             | Jon Hopkins     | Album      | [Apple Music](https://music.apple.com/album/766062577), [Spotify](https://open.spotify.com/album/1rxWlYQcH945S3jpIMYR35)
-| Light Years          | Stellardrone    | Album      | [Apple Music](https://music.apple.com/album/669237623), [Spotify](https://open.spotify.com/album/6uQHo7feNU73mKn8X69pwk)
-| Movements            | Solar Fields    | Album      | [Apple Music](https://music.apple.com/album/1572605925), [Spotify](https://open.spotify.com/album/26sqA3KtarBkOXvR33FNQs)
-| No Man's Sky OST     | 65daysofstatic  | Soundtrack | [Apple Music](https://music.apple.com/album/1469726921), [Spotify](https://open.spotify.com/album/0CkuFPWCLJjCAEKy0dce40)
-| Spiral Revelation    | Steve Roach     | Album      | [Apple Music](https://music.apple.com/album/1184455247), [Spotify](https://open.spotify.com/album/0t7qmuEWN8vtKOJEqzm5T6)
-| Synthwave from Space | Various         | Playlist   | [Spotify](https://open.spotify.com/user/aofd3/playlist/4sgUux9hmykyWYmVoe4W6p) |
-| The Apollo Missions  | NASA            | Album      | [Spotify](https://open.spotify.com/album/3uC3GbmL0BaTIFnrpByd0D)               |
-| Tycho Anthology      | Tycho           | Playlist   | [Apple Music](https://music.apple.com/de/playlist/pl.u-55D6XYqTYb1VZY), [Spotify](https://open.spotify.com/playlist/7m3EiJHdRAVPweCJLxDP3d)
-| X3 OST               | Alexei Zakharov | Soundtrack | [Apple Music](https://music.apple.com/album/495207937), [Spotify](https://open.spotify.com/artist/0V2HC7qeeg8gpoO8cs7ZZX)
+| Name                 | Artist          | Type       | Link                                                                                                                                        |
+| -------------------- | --------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Immunity             | Jon Hopkins     | Album      | [Apple Music](https://music.apple.com/album/766062577), [Spotify](https://open.spotify.com/album/1rxWlYQcH945S3jpIMYR35)                    |
+| Light Years          | Stellardrone    | Album      | [Apple Music](https://music.apple.com/album/669237623), [Spotify](https://open.spotify.com/album/6uQHo7feNU73mKn8X69pwk)                    |
+| Movements            | Solar Fields    | Album      | [Apple Music](https://music.apple.com/album/1572605925), [Spotify](https://open.spotify.com/album/26sqA3KtarBkOXvR33FNQs)                   |
+| No Man's Sky OST     | 65daysofstatic  | Soundtrack | [Apple Music](https://music.apple.com/album/1469726921), [Spotify](https://open.spotify.com/album/0CkuFPWCLJjCAEKy0dce40)                   |
+| Spiral Revelation    | Steve Roach     | Album      | [Apple Music](https://music.apple.com/album/1184455247), [Spotify](https://open.spotify.com/album/0t7qmuEWN8vtKOJEqzm5T6)                   |
+| Synthwave from Space | Various         | Playlist   | [Spotify](https://open.spotify.com/user/aofd3/playlist/4sgUux9hmykyWYmVoe4W6p)                                                              |
+| The Apollo Missions  | NASA            | Album      | [Spotify](https://open.spotify.com/album/3uC3GbmL0BaTIFnrpByd0D)                                                                            |
+| Tycho Anthology      | Tycho           | Playlist   | [Apple Music](https://music.apple.com/de/playlist/pl.u-55D6XYqTYb1VZY), [Spotify](https://open.spotify.com/playlist/7m3EiJHdRAVPweCJLxDP3d) |
+| X3 OST               | Alexei Zakharov | Soundtrack | [Apple Music](https://music.apple.com/album/495207937), [Spotify](https://open.spotify.com/artist/0V2HC7qeeg8gpoO8cs7ZZX)                   |


### PR DESCRIPTION
Mostly adding Apple Music links, but a handful of Spotify links (where there was only an Apple Music link before) are also included.

Also fixed a few of names/typos.

Removed the trailing `   |` from all changed lines, as this just gets too unwieldy and hard to read in an editor - would have had to touch every single line in every table, including headings, which would have made the diff really hard to read.